### PR TITLE
The experiment for variable_validation has ended and can now be used …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 terraform {
   required_version = "~> 0.12"
-  experiments      = [variable_validation]
   required_providers {
     http   = "~> 1.2"
     null   = "~> 2.1"


### PR DESCRIPTION
Fixes this if you use 0.13

```
Error: Experiment has concluded

  on .terraform/modules/k3s/terraform-module-k3s-2.0.1/main.tf line 3, in terraform:
   3:   experiments      = [variable_validation]

Experiment "variable_validation" is no longer available. Custom variable
validation can now be used by default, without enabling an experiment.
```